### PR TITLE
Add View factory method to ShowView, Add Null checks

### DIFF
--- a/Ui.Wpf.Common/Extensions/DockingManagerExtensions.cs
+++ b/Ui.Wpf.Common/Extensions/DockingManagerExtensions.cs
@@ -27,7 +27,7 @@ namespace Ui.Wpf.Common.Extensions
         public static T FindByViewId<T>(this ILayoutContainer root, string viewId)
             where T : LayoutContent
         {
-            return root.Descendents()
+            return root?.Descendents()
                 .OfType<T>()
                 .FirstOrDefault(x => x.ContentId == viewId);
         }

--- a/Ui.Wpf.Common/IShell.cs
+++ b/Ui.Wpf.Common/IShell.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using MahApps.Metro.Controls;
+using System;
 using System.Threading.Tasks;
 using System.Windows;
 using Ui.Wpf.Common.ShowOptions;
@@ -25,6 +26,17 @@ namespace Ui.Wpf.Common
         void CloseViewIn(string containerName, string viewId);
         void CloseToolIn(string containerName, string viewId);
 
+        void ShowView(
+            Func<ILifetimeScope, IView> viewFactory,
+            ViewRequest viewRequest = null,
+            UiShowOptions options = null);
+
+        void ShowViewIn(
+            string containerName,
+            Func<ILifetimeScope, IView> viewFactory,
+            ViewRequest viewRequest = null,
+            UiShowOptions options = null);
+
         void ShowView<TView>(
             ViewRequest viewRequest = null,
             UiShowOptions options = null)
@@ -35,6 +47,17 @@ namespace Ui.Wpf.Common
             ViewRequest viewRequest = null,
             UiShowOptions options = null)
             where TView : class, IView;
+
+        void ShowTool(
+            Func<ILifetimeScope, IToolView> toolFactory,
+            ViewRequest viewRequest = null,
+            UiShowOptions options = null);
+
+        void ShowToolIn(
+            string containerName,
+            Func<ILifetimeScope, IToolView> toolFactory,
+            ViewRequest viewRequest = null,
+            UiShowOptions options = null);
 
         void ShowTool<TToolView>(
             ViewRequest viewRequest = null,
@@ -47,22 +70,42 @@ namespace Ui.Wpf.Common
             UiShowOptions options = null)
             where TToolView : class, IToolView;
 
+        Task<TResult> ShowFlyoutView<TResult>(
+            Func<ILifetimeScope, IView> viewFactory,
+            ViewRequest viewRequest = null,
+            UiShowFlyoutOptions options = null);
+
         Task<TResult> ShowFlyoutView<TView, TResult>(
             ViewRequest viewRequest = null,
             UiShowFlyoutOptions options = null)
             where TView : class, IView;
+
+        void ShowFlyoutView(
+            Func<ILifetimeScope, IView> viewFactory,
+            ViewRequest viewRequest = null,
+            UiShowFlyoutOptions options = null);
 
         void ShowFlyoutView<TView>(
             ViewRequest viewRequest = null,
             UiShowFlyoutOptions options = null)
             where TView : class, IView;
 
-        void ShowChildWindowView<TView>(
+        Task<TResult> ShowChildWindowView<TResult>(
+            Func<ILifetimeScope, IView> viewFactory,
+            ViewRequest viewRequest = null,
+            UiShowChildWindowOptions options = null);
+
+        Task<TResult> ShowChildWindowView<TView, TResult>(
             ViewRequest viewRequest = null,
             UiShowChildWindowOptions options = null)
             where TView : class, IView;
 
-        Task<TResult> ShowChildWindowView<TView, TResult>(
+        void ShowChildWindowView(
+            Func<ILifetimeScope, IView> viewFactory,
+            ViewRequest viewRequest = null,
+            UiShowChildWindowOptions options = null);
+
+        void ShowChildWindowView<TView>(
             ViewRequest viewRequest = null,
             UiShowChildWindowOptions options = null)
             where TView : class, IView;

--- a/Ui.Wpf.Common/Shell.cs
+++ b/Ui.Wpf.Common/Shell.cs
@@ -618,7 +618,8 @@ namespace Ui.Wpf.Common
 
         private static void CloseContent(LayoutContent layout)
         {
-            if (layout.Content is IView view &&
+            if (layout != null &&
+                layout.Content is IView view &&
                 view.ViewModel is ViewModelBase vm)
                 vm.Close();
         }

--- a/Ui.Wpf.Demo/Bootstrap.cs
+++ b/Ui.Wpf.Demo/Bootstrap.cs
@@ -20,6 +20,10 @@ namespace Ui.Wpf.Demo
             builder.RegisterType<MainView>();
             builder.RegisterType<MainViewModel>();
 
+            builder
+                .RegisterType<MainView>()
+                .Named<IView>("main_view");
+
             builder.RegisterType<FlyoutDemoView>();
             builder.RegisterType<FlyoutDemoViewModel>();
 

--- a/Ui.Wpf.Demo/ViewModels/ToolsViewModel.cs
+++ b/Ui.Wpf.Demo/ViewModels/ToolsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using ReactiveUI;
+﻿using Autofac;
+using ReactiveUI;
 using System.Reactive;
 using Ui.Wpf.Common;
 using Ui.Wpf.Common.ShowOptions;
@@ -10,6 +11,7 @@ namespace Ui.Wpf.Demo.ViewModels
     public class ToolsViewModel : ViewModelBase
     {
         public ReactiveCommand<Unit, Unit> ShowMainViewCommand { get; set; }
+        public ReactiveCommand<Unit, Unit> ShowMainViewNamedCommand { get; set; }
         public ReactiveCommand<Unit, Unit> ShowFlyoutDemoViewCommand { get; set; }
         public ReactiveCommand<Unit, Unit> ShowChildWindowViewCommand { get; set; }
         public ReactiveCommand<Unit, Unit> CloseMainViewCommand { get; set; }
@@ -21,6 +23,14 @@ namespace Ui.Wpf.Demo.ViewModels
                 shell.ShowView<MainView>(
                     new ViewRequest("main-view"),
                     new UiShowOptions {Title = nameof(MainView)}
+                );
+            });
+            ShowMainViewNamedCommand = ReactiveCommand.Create(() =>
+            {
+                shell.ShowView(
+                    c => c.ResolveNamed<IView>("main_view"),
+                    new ViewRequest("main-view-named"),
+                    new UiShowOptions { Title = nameof(MainView) }
                 );
             });
             ShowFlyoutDemoViewCommand = ReactiveCommand.Create(() =>

--- a/Ui.Wpf.Demo/Views/ToolsView.xaml
+++ b/Ui.Wpf.Demo/Views/ToolsView.xaml
@@ -11,6 +11,7 @@
     <Grid>
         <StackPanel>
             <Button Margin="5 5 5 0" Command="{Binding ShowMainViewCommand}">Show Main View</Button>
+            <Button Margin="5 5 5 0" Command="{Binding ShowMainViewNamedCommand}">Show Main View Named</Button>
             <Button Margin="5 5 5 0" Command="{Binding ShowFlyoutDemoViewCommand}">Show Flyout Demo View</Button>
             <Button Margin="5 5 5 0" Command="{Binding ShowChildWindowViewCommand}">Show Child Window View</Button>
             <Button Margin="5 5 5 0" Command="{Binding CloseMainViewCommand}">Close Main View</Button>


### PR DESCRIPTION
- Added View factory method to ShowView
This change adds fine grained control of view instantiation:
```csharp
shell.ShowView(
    c => c.ResolveNamed<IView>("main_view"),
    new ViewRequest("main-view-named"),
    new UiShowOptions { Title = nameof(MainView) }
);
```
- Added Null checks in CloseContent and FindByViewId
With this change multiple CloseView calls will not throw NPE